### PR TITLE
Fix fpanettieri/unity-socket.io#38

### DIFF
--- a/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
+++ b/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
@@ -350,7 +350,6 @@ namespace SocketIO
 			debugMethod.Invoke("[SocketIO] Socket.IO sid: " + packet.json["sid"].str);
 			#endif
 			sid = packet.json["sid"].str;
-			EmitEvent("open");
 		}
 
 		private void HandlePing()


### PR DESCRIPTION
Admittedly, this may not be the best solution for this issue. That being said, it seems like the EmitEvent("Open") that this PR removes from HandleOpen is accurate, since this instance can be perceived as a lie, being message driven. Whereas, the remaining EmitEvent("Open") in OnOpen is entirely truthful, since it is only fired when WebSocket.OnOpen fires (i.e., upon successful connection).
